### PR TITLE
Update Chicory and run in the 3 modes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,8 @@ build/
 
 ### Mac OS ###
 .DS_Store
+
+*.txt
+dependency-reduced-pom.xml
+
+.idea/

--- a/pom.xml
+++ b/pom.xml
@@ -12,12 +12,24 @@
         <uberjar.name>benchmarks</uberjar.name>
         <exec.mainClass>garden.bots.starter.Main</exec.mainClass>
         <graalvm.polyglot.version>24.0.2</graalvm.polyglot.version>
-        <chicory.version>0.0.12</chicory.version>
+        <chicory.version>1.0.0-M1</chicory.version>
         <jmh.version>1.37</jmh.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
+
+      <dependencyManagement>
+        <dependencies>
+        <dependency>
+            <groupId>com.dylibso.chicory</groupId>
+            <artifactId>bom</artifactId>
+            <version>${chicory.version}</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <!-- GraalWasm -->
@@ -36,24 +48,23 @@
         <!-- Chicory -->
         <dependency>
             <groupId>com.dylibso.chicory</groupId>
+            <artifactId>aot-experimental</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.dylibso.chicory</groupId>
             <artifactId>runtime</artifactId>
-            <version>${chicory.version}</version>
         </dependency>
         <dependency>
             <groupId>com.dylibso.chicory</groupId>
             <artifactId>wasi</artifactId>
-            <version>${chicory.version}</version>
         </dependency>
         <dependency>
             <groupId>com.dylibso.chicory</groupId>
             <artifactId>log</artifactId>
-            <version>${chicory.version}</version>
         </dependency>
-        <!-- Chicory -->
         <dependency>
             <groupId>com.dylibso.chicory</groupId>
             <artifactId>wasm</artifactId>
-            <version>${chicory.version}</version>
         </dependency>
         
         <!-- JMH -->
@@ -72,6 +83,23 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>com.dylibso.chicory</groupId>
+        <artifactId>aot-maven-plugin-experimental</artifactId>
+        <executions>
+          <execution>
+            <id>demo-plugin</id>
+            <goals>
+              <goal>wasm-aot-gen</goal>
+            </goals>
+            <configuration>
+              <name>org.graalvm.benchmark.Demo</name>
+              <wasmFile>demo-plugin/demo.wasm</wasmFile>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>

--- a/src/main/java/org/graalvm/benchmark/ChicoryTest.java
+++ b/src/main/java/org/graalvm/benchmark/ChicoryTest.java
@@ -1,8 +1,14 @@
 package org.graalvm.benchmark;
 
-import java.io.IOException;
-import java.util.concurrent.TimeUnit;
-
+import com.dylibso.chicory.experimental.aot.AotMachine;
+import com.dylibso.chicory.log.SystemLogger;
+import com.dylibso.chicory.runtime.ExportFunction;
+import com.dylibso.chicory.runtime.ImportValues;
+import com.dylibso.chicory.runtime.Instance;
+import com.dylibso.chicory.runtime.Memory;
+import com.dylibso.chicory.wasi.WasiOptions;
+import com.dylibso.chicory.wasi.WasiPreview1;
+import com.dylibso.chicory.wasm.Parser;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -10,6 +16,7 @@ import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
@@ -17,15 +24,8 @@ import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 
-import com.dylibso.chicory.log.SystemLogger;
-import com.dylibso.chicory.runtime.ExportFunction;
-import com.dylibso.chicory.runtime.Module;
-import com.dylibso.chicory.wasi.WasiOptions;
-import com.dylibso.chicory.wasm.types.Value;
-import com.dylibso.chicory.runtime.Memory;
-import com.dylibso.chicory.runtime.HostImports;
-import com.dylibso.chicory.runtime.Instance;
-import com.dylibso.chicory.wasi.WasiPreview1;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 
 @Warmup(iterations = 3)
 @Measurement(iterations = 3)
@@ -33,11 +33,21 @@ import com.dylibso.chicory.wasi.WasiPreview1;
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @Fork(1)
 public class ChicoryTest {
-  
+    private static final String INTERPRETER = "interpreter";
+    private static final String RUNTIME_AOT = "runtime-aot";
+    private static final String PRECOMPILED_AOT = "precompiled-aot";
+
     @State(Scope.Thread)
     public static class ChicoryFixture extends WasmTestFixture {
         public WasiPreview1 wasi;
         public Instance instance;
+
+        @Param({
+                INTERPRETER,
+                RUNTIME_AOT,
+                PRECOMPILED_AOT
+        })
+        private String mode;
 
         @Setup(Level.Trial)
         public void doSetup() throws IOException {
@@ -45,11 +55,22 @@ public class ChicoryTest {
             final var logger = new SystemLogger();
             // create our instance of wasip1
             wasi = new WasiPreview1(logger, WasiOptions.builder().build());
-            final var imports = new HostImports(wasi.toHostFunctions());
-            // create the module
-            final var module = Module.builder(this.wasmBytes).withHostImports(imports).build();
-            // instantiate (the module) and connect our imports
-            instance = module.instantiate();
+            final var imports = ImportValues.builder().addFunction(wasi.toHostFunctions()).build();
+            // create the module and instantiate (the module) and connect our imports
+            var instanceBuilder = Instance.builder(Parser.parse(wasmBytes));
+            switch (mode) {
+                case INTERPRETER:
+                    break;
+                case RUNTIME_AOT:
+                    instanceBuilder.withMachineFactory(AotMachine::new);
+                    break;
+                case PRECOMPILED_AOT:
+                    instanceBuilder.withMachineFactory(DemoMachineFactory::create);
+                    break;
+                default:
+                    throw new IllegalArgumentException("Unknown Chicory mode " + mode);
+            }
+            instance = instanceBuilder.withImportValues(imports).build();
         }
 
         @TearDown(Level.Trial)
@@ -67,22 +88,22 @@ public class ChicoryTest {
         final Memory memory = fixture.instance.memory();
 
         // allocate {fixture.paramLen} bytes of memory, this returns a pointer to that memory
-        final int ptr = malloc.apply(Value.i32(fixture.paramLen))[0].asInt();
+        final int ptr = (int) malloc.apply(fixture.paramLen)[0];
         // We can now write the message to the module's memory:
         memory.writeString(ptr, fixture.param);
 
         // Call the wasm function
-        final Value result = wasmFunc.apply(Value.i32(ptr), Value.i32(fixture.paramLen))[0];
+        final int result = (int) wasmFunc.apply(ptr, fixture.paramLen)[0];
         // free input string memory
-        free.apply(Value.i32(ptr), Value.i32(fixture.paramLen));
+        free.apply(ptr);
 
         // Extract position and size from the result
-        final int valuePosition = (int) ((result.asLong() >>> 32) & 0xFFFFFFFFL);
-        final int valueSize = (int) (result.asLong() & 0xFFFFFFFFL);
+        final int valuePosition = (int) ((result >>> 32) & 0xFFFFFFFFL);
+        final int valueSize = (int) (result & 0xFFFFFFFFL);
 
         // get byte[] of the result
         byte[] message = memory.readBytes(valuePosition, valueSize);
 
-        blackhole.consume(message);   
+        blackhole.consume(message);
     }
 }


### PR DESCRIPTION
Chicory updated to the latest `1.0.0-M1` release.
I don't expect much variation in numbers across runtime/pre-compiled AOT as they are essentially different ways of "distributing" the same thing.